### PR TITLE
Fix crash when compressing uncompressed GBX file + Replacing argument parsing with argp.h

### DIFF
--- a/src/gbx.c
+++ b/src/gbx.c
@@ -133,7 +133,7 @@ void write_gbx_file(char* path, gbx_file* gbx, bool compress) {
     
     if(compress) {
         int compsize;
-        char* compdata = malloc( (gbx->bodysize + gbx->bodysize) / 16 + 64 + 3);
+        char* compdata = malloc( gbx->bodysize + gbx->bodysize / 16 + 64 + 3);
         if(verbose) printf("Compressing...\n");
         lzo1x_1_compress(gbx->bodydata, gbx->bodysize, compdata, &compsize, wrkmem);
         if(verbose) printf("Compressed, compressed size %d\n", compsize);

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@ enum COMP_MODE {
 bool verbose = false;
 uint8_t compmode = AUTO;
 
-const char* VER = "1.0.5";
+const char* VER = "1.0.6";
 
 void prnt_help() {
     printf("GBXLZO v%s by GreffMASTER\n", VER);
@@ -19,9 +19,9 @@ void prnt_help() {
     printf("-v         -  verbose\n");
     printf("-c         -  only compress\n");
     printf("-u         -  only decompress\n");
-    printf("-o <path>  -  output path");
-    printf("If output path is not provided, the input file will be used as output");
-    printf("By default, the program will decompress compressed files and vice versa");
+    printf("-o <path>  -  output path\n");
+    printf("If output path is not provided, the input file will be used as output\n");
+    printf("By default, the program will decompress compressed files and vice versa\n");
 }
 
 int main(int argc, char** argv) {
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
         } else if(strcmp(argv[i], "-o") == 0) {
             requiredargs += 2;
             if(argc<requiredargs) {
-                printf("-o parameter requires a path");
+                printf("-o parameter requires a path\n");
                 prnt_help();
                 return 0;
             }

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,7 @@
 #include "gbx.h"
+#include <argp.h>
+
+#define VER "1.0.7"
 
 enum COMP_MODE {
     AUTO = 0,
@@ -8,52 +11,59 @@ enum COMP_MODE {
 
 bool verbose = false;
 uint8_t compmode = AUTO;
+char* inpath = NULL;
+char* outpath = NULL;
 
-const char* VER = "1.0.6";
+const char *argp_program_version = "GBXLZO v" VER " by GreffMASTER";
+const char *argp_program_bug_address = ""; //Insert an appropriate E-mail address here
+static char doc[] = "A tool for decompressing/compressing GameBox files. (*.Gbx)";
+static char args_doc[] = "<infile>";
+static struct argp_option options[] = {
+    {"compress",   'c', 0,           0, "only compress"},
+    {"uncompress", 'u', 0,           0, "only decompress"},
+    {"output",     'o', "FILE", 0, "output path. If not provided, the input file will be used as output"},
+    {"verbose",    'v', 0,           0, "verbose"},
+    { 0 }
+};
 
-void prnt_help() {
-    printf("GBXLZO v%s by GreffMASTER\n", VER);
-    printf("A tool for decompressing/compressing GameBox files. (*.Gbx)\n");
-    printf("Usage: gbxlzo <infile> [params]\n");
-    printf("Parameters:\n");
-    printf("-v         -  verbose\n");
-    printf("-c         -  only compress\n");
-    printf("-u         -  only decompress\n");
-    printf("-o <path>  -  output path\n");
-    printf("If output path is not provided, the input file will be used as output\n");
-    printf("By default, the program will decompress compressed files and vice versa\n");
+error_t argp_parser (int key, char *arg, struct argp_state *state){
+    switch(key){
+        case 'v':
+            verbose = true;
+            break;
+
+        case 'c':
+            compmode = COMPRESS;
+            break;
+
+        case 'd':
+            compmode = UNCOMPRESS;
+            break;
+
+        case 'o':
+            outpath = arg;
+            break;
+
+        case ARGP_KEY_NO_ARGS: //No arguments
+            argp_usage(state); //No break, this exits
+
+        case ARGP_KEY_ARG: //Input file name
+            inpath = arg;
+            state->next = state->argc;
+            break;
+
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }       
+    return 0;
 }
 
+static struct argp argp = { options, argp_parser, args_doc, doc, 0, 0, 0 };
+
 int main(int argc, char** argv) {
-    char* inpath = NULL;
-    char* outpath = NULL;
-    int requiredargs = 2;
-    if(argc<2) {
-        prnt_help();
-        return 0;
-    }
-    inpath = argv[1];
-    outpath = argv[1];
-    for(int i=2;i<argc;i++) {
-        if(strcmp(argv[i], "-v") == 0) {
-            requiredargs += 1;
-            verbose = true;
-        } else if(strcmp(argv[i], "-c") == 0) {
-            requiredargs += 1;
-            compmode = COMPRESS;
-        } else if(strcmp(argv[i], "-u") == 0) {
-            requiredargs += 1;
-            compmode = UNCOMPRESS;
-        } else if(strcmp(argv[i], "-o") == 0) {
-            requiredargs += 2;
-            if(argc<requiredargs) {
-                printf("-o parameter requires a path\n");
-                prnt_help();
-                return 0;
-            }
-            outpath = argv[i+1];
-        }
-    }
+    
+    argp_parse(&argp, argc, argv, 0, 0, 0);
+
     if (lzo_init() != LZO_E_OK) {
         printf("Error: failed to initialize LZO\n");
         return 3;


### PR DESCRIPTION
This fixes the compressed data buffer being incorrectly sized (`(gbx->bodysize + gbx->bodysize) / 16 + 64 + 3` instead of `gbx->bodysize + gbx->bodysize / 16 + 64 + 3`), causing a segfault.
This also adds a few `\n`s that were not here in printfs.